### PR TITLE
Make this repo less Serby-centric

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Usage
 
 ## Credits
-[Paul Serby](https://github.com/serby/) follow me on twitter [@serby](http://twitter.com/serby)
+Built by developers at [Clock](http://clock.co.uk).
 
 ## Licence
 Licensed under the [New BSD License](http://opensource.org/licenses/bsd-license.php)

--- a/go.sh
+++ b/go.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+gitUserName=`git config --get user.name`
+
 read -e -p "Name of package: " name
 read -e -p "Description of package: " description
 read -e -p "Github Owner: [clocklimited] " githubUser
-read -e -p  "Author: [Paul Serby <paul.serby@clock.co.uk>] " author
+read -e -p  "Author: [$gitUserName] " author
 
 githubUser=${githubUser:-clocklimited}
-author=${author:-Paul Serby <paul.serby@clock.co.uk>}
+author=${author:-`echo $gitUserName`}
 
 sed -i -e "s/{NAME}/$name/g" README.md package.json
 sed -i -e "s/{DESCRIPTION}/$description/g" README.md package.json


### PR DESCRIPTION
This change gets the user name in a system agnostic way (tested on my OSX and @microadam's flavour of Linux) with whatever your git config user name is. It only defaults to this, you still have the ability to override. Also removed Paul Serby from the credits for a generic "developers at Clock" line.
