### PR TITLE
Removing Pliers from module development

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
 , "devDependencies":
   { "mocha": "*"
   , "should": "*"
+  , "jshint": "*"
   }
 }


### PR DESCRIPTION
I have removed pliers due to it being over-kill for most npm modules. I have also added a pre-publish condition to ensure that code is linted and tests are passing at time of publishing.

`npm run-script lint` will run the linter specified in package.json

Any publish will need both the lint and the tests passing.

The `pretest` condition ensures both the lint and the test results are shown in the test output.
