### PR TITLE
Fix package.json coding style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,31 @@
-{ "author": "{AUTHOR}"
-, "name": "{NAME}"
-, "description": "{DESCRIPTION}"
-, "version": "0.0.1"
-, "tags": []
-, "repository":
-  { "type": "git"
-  , "url": "git@github.com:{GITHUBOWNER}/{NAME}"
-  }
-, "publishConfig": {
+{
+  "author": "{AUTHOR}",
+  "name": "{NAME}",
+  "description": "{DESCRIPTION}",
+  "version": "0.0.1",
+  "tags": [],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:{GITHUBOWNER}/{NAME}"
+  },
+  "publishConfig": {
     "registry": "http://npm.clockte.ch"
-  }
-, "main": ""
-, "scripts":
-  { "lint": "./node_modules/.bin/jshint . --reporter=./node_modules/jshint-full-path/index.js"
-  , "pretest": "npm run-script lint; exit 0"
-  , "test": "./node_modules/.bin/mocha -R spec"
-  , "prepublish": "npm run-script lint && npm test"
-  }
-, "engines":
-  { "node": ">=0.8"
-  }
-, "dependencies":
-  {
-  }
-, "devDependencies":
-  { "mocha": "*"
-  , "should": "*"
-  , "jshint": "*"
-  , "jshint-full-path": "*"
+  },
+  "main": "",
+  "scripts": {
+    "lint": "./node_modules/.bin/jshint . --reporter=./node_modules/jshint-full-path/index.js",
+    "pretest": "npm run-script lint; exit 0",
+    "test": "./node_modules/.bin/mocha -R spec",
+    "prepublish": "npm run-script lint && npm test"
+  },
+  "engines": {
+    "node": ">=0.8"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "mocha": "*",
+    "should": "*",
+    "jshint": "*",
+    "jshint-full-path": "*"
   }
 }


### PR DESCRIPTION
Using `npm install [package] --save` reverts our package.json file to this format so I think we should use this coding style.

I would like to use `--save` and `--save-dev` without having to manually revert the changes it makes.
